### PR TITLE
assignee_field is now optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wildflowerschools/graphql-beehive",
-    "version": "0.7.6",
+    "version": "0.7.7",
     "description": "A set of tools for working with PostgreSQL and GraphQL",
     "main": "src/index.js",
     "repository": "https://github.com/WildflowerSchools/graphql-beehive",

--- a/src/hive/types.js
+++ b/src/hive/types.js
@@ -33,7 +33,7 @@ exports.BeehiveTypeDefs = `
     
     directive @beehiveRelation(target_type_name: String!, target_field_name: String) on FIELD_DEFINITION
 
-    directive @beehiveAssignmentType(table_name: String, pk_column: String, assigned_field: String!, assignee_field: String!, start_field_name: String, end_field_name: String, exclusive: Boolean) on OBJECT
+    directive @beehiveAssignmentType(table_name: String, pk_column: String, assigned_field: String!, assignee_field: String, start_field_name: String, end_field_name: String, exclusive: Boolean) on OBJECT
 
     directive @beehiveUnion on UNION
 


### PR DESCRIPTION
it isn't really used yet and I can think of cases where it isn't required or useful. I think the intent was to allow for an assignment that is not exclusive to e exclusive to one assignee, but we only implemented the exclusive case.